### PR TITLE
little clean on the RayState Init function

### DIFF
--- a/source/jf_nested_dielectric/jf_nested_dielectric.h
+++ b/source/jf_nested_dielectric/jf_nested_dielectric.h
@@ -524,7 +524,6 @@ typedef struct RayState {
         this->dr_accumRoughness = 0.0;
 
         // Set once values - values set at initialization for all descendent rays
-        this->energy_cutoff = pow(10.0f, 16);
         this->polarized = AiShaderEvalParamBool(p_polarize);
         this->polarizationVector = polarizationVector;
 


### PR DESCRIPTION
It seems that this assignation is not necessary as the assignation done after overwrite it. 